### PR TITLE
feature: improve usability

### DIFF
--- a/src/components/DistanceMeasurement/DistanceMeasurement.tsx
+++ b/src/components/DistanceMeasurement/DistanceMeasurement.tsx
@@ -16,16 +16,25 @@ export const DistanceMeasurement = ({
   };
   return (
     <div
-      className="absolute top-10 left-1/2 -translate-x-1/2 z-10 "
+      className="absolute top-10 left-1/2 -translate-x-1/2 z-10 w-75"
       aria-label="Distance measurement"
     >
       <div className="frosted px-4 py-2 rounded flex flex-col gap-y-4">
-        <p>
-          Total distance: <span>{distance}</span>
-        </p>
-        <Button onClick={clearMeasurements} size="sm">
-          clear
-        </Button>
+        <p>Measure distance</p>
+        {distance === '' && <small>Click on the map to trace a path you want to measure</small>}
+        {distance !== '' && (
+          <>
+            <div>
+              <small>Click on the map to add to your path</small>
+              <div>
+                Total distance: <span>{distance}</span>
+              </div>
+            </div>
+            <Button onClick={clearMeasurements} size="sm">
+              clear
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/FeaturesMenu/FeaturesMenu.stories.tsx
+++ b/src/components/FeaturesMenu/FeaturesMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { LayersIcon, MapsIcon } from '../Icons';
 import { FeaturesMenu } from './FeaturesMenu';
-import { LayersIcon, MapsIcon, MeasuresIcon } from '../Icons';
 
 const meta = {
   title: 'components/FeaturesMenu',
@@ -19,7 +19,6 @@ export const Primary: Story = {
     features: [
       { icon: LayersIcon, label: 'Options' },
       { icon: MapsIcon, label: 'Maps' },
-      { icon: MeasuresIcon, label: 'Measurement' },
     ],
   },
 };

--- a/src/components/FeaturesMenu/FeaturesMenu.tsx
+++ b/src/components/FeaturesMenu/FeaturesMenu.tsx
@@ -8,7 +8,7 @@ import { NumParticles, useMapUIStore } from '@/store';
 import { useShallow } from 'zustand/shallow';
 import { Switch } from '../Switch';
 
-export type Label = 'Options' | 'Maps' | 'Measurement';
+export type Label = 'Options' | 'Maps';
 
 export type MenuItem = {
   icon: React.FC<IconProps>;
@@ -107,21 +107,33 @@ export function FeaturesMenu({
       {!!activeItem && (
         <div className="mt-2 p-2">
           {activeItem === 'Options' && (
-            <div>
-              <Dropdown
-                label="number of particles"
-                onChange={
-                  handleNumParticlesSelect as (value: string | number | (string | number)[]) => void
-                }
-                options={numParticlesDropdownSelections}
-                initialValue={numParticles || numParticlesDropdownSelections[0].value}
-                position="auto"
-                usePortal
-              />
-            </div>
+            <>
+              <div className="pr-2 pl-2 pb-2">
+                <Dropdown
+                  label="number of particles"
+                  onChange={
+                    handleNumParticlesSelect as (
+                      value: string | number | (string | number)[],
+                    ) => void
+                  }
+                  options={numParticlesDropdownSelections}
+                  initialValue={numParticles || numParticlesDropdownSelections[0].value}
+                  position="auto"
+                  usePortal
+                />
+              </div>
+              <div className="pt-2">
+                <Switch
+                  label="Measure distance"
+                  labelPosition="left"
+                  initialValue={distanceMeasurement}
+                  onChange={handleDistanceMeasurementSelect}
+                />
+              </div>
+            </>
           )}
           {activeItem === 'Maps' && (
-            <div>
+            <div className="pl-2 pr-2">
               <Dropdown
                 label="map style"
                 onChange={
@@ -131,16 +143,6 @@ export function FeaturesMenu({
                 initialValue={style || styleDropdownSelections[0].value}
                 position="auto"
                 usePortal
-              />
-            </div>
-          )}
-          {activeItem === 'Measurement' && (
-            <div>
-              <Switch
-                label="Distance Measurement"
-                labelPosition="top"
-                initialValue={distanceMeasurement}
-                onChange={handleDistanceMeasurementSelect}
               />
             </div>
           )}

--- a/src/components/FloatingPanel/FloatingPanel.stories.tsx
+++ b/src/components/FloatingPanel/FloatingPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { FeaturesMenu, LayersIcon, MapsIcon } from '..';
 import { FloatingPanel } from './FloatingPanel';
-import { FeaturesMenu, LayersIcon, MapsIcon, MeasuresIcon } from '..';
 const meta = {
   title: 'components/FloatingPanel',
   component: FloatingPanel,
@@ -20,7 +20,6 @@ export const Collapsible: Story = {
         features={[
           { icon: LayersIcon, label: 'Options' },
           { icon: MapsIcon, label: 'Maps' },
-          { icon: MeasuresIcon, label: 'Measurement' },
         ]}
       />
     ),
@@ -39,7 +38,6 @@ export const Uncollapsible: Story = {
         features={[
           { icon: LayersIcon, label: 'Options' },
           { icon: MapsIcon, label: 'Maps' },
-          { icon: MeasuresIcon, label: 'Measurement' },
         ]}
       />
     ),

--- a/src/components/MapComponent/MapComponent.tsx
+++ b/src/components/MapComponent/MapComponent.tsx
@@ -81,7 +81,7 @@ export const MapComponent = memo(() => {
   return (
     <>
       <div ref={mapContainer} className={cn('w-full h-full')} />
-      {distance && (
+      {distanceMeasurement && (
         <DistanceMeasurement
           distance={distance}
           setDistance={setDistance}

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -146,7 +146,7 @@ export const Switch = ({
 
   const labelElement = label && (
     <div className="flex flex-col">
-      <span className={cn('text-sm font-medium text-gray-900', labelClassName)}>{label}</span>
+      <span className={cn('text-sm font-medium text-gray-700', labelClassName)}>{label}</span>
       {description && (
         <span className={cn('text-xs text-gray-500', descriptionClassName)}>{description}</span>
       )}
@@ -159,7 +159,7 @@ export const Switch = ({
 
   return (
     <div
-      className={cn('flex items-center gap-3', {
+      className={cn('flex items-center gap-4', {
         'flex-row-reverse': labelPosition === 'left',
         'flex-col-reverse items-start': labelPosition === 'top',
         'flex-col': labelPosition === 'bottom',

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,8 @@ body {
 .custom-popup .mapboxgl-popup-tip {
   @apply border-t-white;
 }
+
+/* Highcharts navigator cursor override */
+.highcharts-navigator-mask-inside {
+  cursor: grab !important;
+}

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -10,7 +10,6 @@ import {
   MapComponent,
   Header as MapHeader,
   MapsIcon,
-  MeasuresIcon,
   SatelliteIcon,
   Sidebar,
   WaterSurfaceIcon,
@@ -83,7 +82,6 @@ export const Map = () => {
                 features={[
                   { icon: LayersIcon, label: 'Options' },
                   { icon: MapsIcon, label: 'Maps' },
-                  { icon: MeasuresIcon, label: 'Measurement' },
                 ]}
               />
             }

--- a/tests/happyPath.spec.ts
+++ b/tests/happyPath.spec.ts
@@ -513,7 +513,7 @@ test.describe('Measurement', () => {
     await page.goto('/');
   });
   test('User can measure distance', async ({ page }) => {
-    await page.getByRole('menuitem', { name: 'Measurement' }).click();
+    await page.getByRole('menuitem', { name: 'Options' }).click();
     await page.getByRole('switch').click();
 
     await mapComponent.waitUntilLayerLoaded(page, MEASURE_POINTS_LAYER_ID);
@@ -525,15 +525,17 @@ test.describe('Measurement', () => {
     const measurementPopup = page.getByLabel('Distance measurement');
     // click at two points to create a measurement
     await page.getByRole('region', { name: 'Map' }).click({ position: { x: bbox!.x, y: bbox!.y } });
-    await expect(measurementPopup).not.toBeVisible();
+    await expect(measurementPopup).toBeVisible();
+    await expect(measurementPopup.getByRole('button', { name: 'clear' })).not.toBeVisible();
     await page
       .getByRole('region', { name: 'Map' })
       .click({ position: { x: bbox!.x + 10, y: bbox!.y } });
-    await expect(measurementPopup).toBeVisible();
+    await expect(measurementPopup.getByRole('button', { name: 'clear' })).toBeVisible();
 
     await expect(measurementPopup.getByText(/^\d+(\.\d+)? km$/)).toBeVisible();
     await measurementPopup.getByRole('button', { name: 'clear' }).click();
-    await expect(measurementPopup).not.toBeVisible();
+    await expect(measurementPopup.getByRole('button', { name: 'clear' })).not.toBeVisible();
+    await expect(measurementPopup).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Measurement layer

Change the way to enable measurement layer:
<img width="212" height="241" alt="image" src="https://github.com/user-attachments/assets/55dc8a19-0e5a-4383-a77b-e4addd687155" />

Add some feedback about what we expect about you once you enable that layer: 
<img width="375" height="203" alt="image" src="https://github.com/user-attachments/assets/acd1f71c-240c-4cea-8cdf-e78aada72cd2" />

Add some more feedback to keep adding dots to your path:

<img width="353" height="182" alt="image" src="https://github.com/user-attachments/assets/a9fd2616-1309-4ff2-94a4-04dd5ca2719f" />


## Timeseries chart: 

Use 2 different icons while using the chart navigator:
1. change the zoom 
<img width="1820" height="1437" alt="image" src="https://github.com/user-attachments/assets/e7fe6dbd-650d-4a8a-86ab-353da25d85f2" />

2. move window but keep same zoom
<img width="1820" height="1437" alt="image" src="https://github.com/user-attachments/assets/5d9f6329-37de-4022-b4af-7fee95bcddd9" />

